### PR TITLE
Adding in COAP_FMT_FORMAT_AUTO type to zcoap-server.

### DIFF
--- a/src/zcoap-server.h
+++ b/src/zcoap-server.h
@@ -114,6 +114,7 @@ typedef enum coap_content_format_e {
     COAP_FMT_CWT = 61,
     COAP_FMT_MULTIPART_CORE = 62,
     COAP_FMT_CBOR_SEQ = 63,
+    COAP_FMT_FORMAT_AUTO = 72,
     COAP_FMT_COSE_ENCRYPT = 96,
     COAP_FMT_COSE_MAC = 97,
     COAP_FMT_COSE_SIGN = 98,


### PR DESCRIPTION
Action: RESOLVE

The temperature controller coap server in V2xx will return a type COAP_FMT_FORMAT_AUTO which was not in the zcoap-server. We added that so that it is clear what type is being returned.